### PR TITLE
added issue 110 "endless room"

### DIFF
--- a/adventure/zdd_adventure.py
+++ b/adventure/zdd_adventure.py
@@ -40,6 +40,9 @@ class ZDDAdventure:
 
         # -------------------------------
         # ... Add other rooms ...
+        # Add the Endless Room to the Second Floor (Issue #110)
+        # Player command: enter loop
+        second_floor.add_room("loop", ALL_ROOMS["endless_room_key"])
 
         return {
             "cellar": cellar,

--- a/adventure/zdd_rooms.py
+++ b/adventure/zdd_rooms.py
@@ -21,9 +21,43 @@ toilet_cellar = ToiletCellar("toilet", "Yes, even the cellar has a toilet.")
 # -----------------------------------------------------------
 # Add YOUR ROOM instance here, similar to the example below:
 # my_room = MyRoom("room_name", "room_description")
+class EndlessRoom(Room):
+    def run_story(self, user_items):
+        self.visited += 1 
+        
+        
+        if self.visited <= 1:
+            print(f"You've entered the {self.name}.")
+            print("When you take your first steps, you realize you are back at the entrance.")
+            print("It feels like you are walking in a circle, but the path is straight.")
+            self.description = "The room seems normal, but every step leads back to the start."
+            
+        
+        elif self.visited < 3:
+            print("You try again, walking the straight line, but you inevitably end up back at the start. The cycle repeats.")
+            
+        
+        elif self.visited == 3:
+            print("You hear a **metallic sound**. Frustrated, you look down and find a strange key lying on the ground!")
+            
+            
+            if self.items == []:
+                 self.items.append(chameleon_key)
+            
+        else:
+            print("The endless cycle continues. Maybe the key can change something?")
 
+        return user_items
+
+
+endless_room = EndlessRoom(
+    name="endless room", 
+    description="The air is still, and you feel a strange pull towards the entrance."
+)
 ALL_ROOMS = {
     "toilet_cellar": toilet_cellar
     # Add your room key-value pairs here:
     # "my_room_key": my_room
+    "endless_room_key": endless_room
+    
 }


### PR DESCRIPTION
the endless room (room label: loop) is a puzzling room located on the second floor of the zdd that forces the player into a loop.


puzzle mechanic: when the player enters the room, the visited count is used. the player lands back at the entrance every time during the first and second attempt to walk through the room.


item spawn: only upon the third entry is a "metallic sound" heard, and the chameleon key is spawned on the ground for the player to pick up.


solution: once the player holds the chameleon key in their inventory, the room's description shifts, signaling that the cycle is broken and the path forward is now clear.